### PR TITLE
add default pkg_config_path

### DIFF
--- a/inc/MyBuilder.pm
+++ b/inc/MyBuilder.pm
@@ -16,6 +16,7 @@ use File::Which;
 
 my @pkg_config_path = qw(
     /usr/local/lib/pkgconfig
+    /usr/lib64/pkgconfig
     /usr/lib/pkgconfig
     /opt/X11/lib/pkgconfig
 );


### PR DESCRIPTION
Failed install rrdtool on CentOS6 with this error.

```
checking for pango_cairo_context_set_font_options in -lpangocairo-1.0... yes
checking pango/pango.h usability... no
checking pango/pango.h presence... yes
configure: WARNING: pango/pango.h: present but cannot be compiled
configure: WARNING: pango/pango.h:     check for missing prerequisite headers?
configure: WARNING: pango/pango.h: see the Autoconf documentation
configure: WARNING: pango/pango.h:     section "Present But Cannot Be Compiled"
configure: WARNING: pango/pango.h: proceeding with the compiler's result
checking for pango/pango.h... no
```

CentOS6's pkg_config_path is /usr/lib64/pkgconfig

```
$ find /usr -name 'pango.pc'
/usr/lib64/pkgconfig/pango.pc
```

This p-r add `/usr/lib64/pkgconfig` to default pkg_config_path of MyBuilder.pm
